### PR TITLE
anonymize to be double-blind

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -12,16 +12,18 @@
 \begin{document}
 
 \title{Augraphy: An Augmentation Pipeline API for Modern Document Images}
-\author{Alexander Groleau\inst{1,2} \and
-Kok Wei Chee\inst{1} \and
-Samay Maini\inst{1} \and
-Jonathan Boarman\inst{1}}
+%\author{Alexander Groleau\inst{1,2} \and
+%Kok Wei Chee\inst{1} \and
+%Samay Maini\inst{1} \and
+%Jonathan Boarman\inst{1}}
+%
+%\authorrunning{A. Groleau et al.}
+%
+%\institute{Sparkfish LLC (\email{augraphy@sparkfish.com})
+%\and
+%Left Associates LLC (\email{research@left.associates})}
 
-\authorrunning{A. Groleau et al.}
-
-\institute{Sparkfish LLC (\email{augraphy@sparkfish.com})
-\and
-Left Associates LLC (\email{research@left.associates})}
+\author{Anonymous ICDAR 2023 submission}
 
 \maketitle
 


### PR DESCRIPTION
- anonymizes the authors in order to adhere to ICDAR's double-blind policy (for ICDAR submission only)