### PR TITLE
re-work related work section

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -1,0 +1,303 @@
+@misc{ref_RDCL2019,
+    author={Clausner, Christian},
+    title={RDCL2019 Competition Dataset (Recognition of Documents with Complex Layouts)},
+    url={https://tc11.cvc.uab.es/datasets/RDCL2019_1},
+    year={2019}
+}
+
+@misc{ref_tobacco800,
+    title={Tobacco 800 Dataset},
+    author={Doermann, David},
+    url={https://tc11.cvc.uab.es/datasets/Tobacco800_1}
+}
+
+% NoisyOffice dataset
+@article{ref_NoisyOffice,
+    author = {Castro-Bleda, M. J. and España-Boquera, S. and Pastor-Pellicer, J. and Zamora-Martínez, F.},
+    title = "{The NoisyOffice Database: A Corpus to Train Supervised Machine Learning Filters for Image Processing}",
+    journal = {The Computer Journal},
+    volume = {63},
+    number = {11},
+    pages = {1658-1667},
+    year = {2019},
+    month = {11},
+    issn = {0010-4620},
+    doi = {10.1093/comjnl/bxz098},
+    url = {https://doi.org/10.1093/comjnl/bxz098},
+    eprint = {https://academic.oup.com/comjnl/article-pdf/63/11/1658/34314962/bxz098.pdf},
+}
+
+@inproceedings{ref_NoisyOfficeDatabase,
+    author={Zamora-Mart\'{i}nez, F. and Espa\~{n}a-Boquera, S. and Castro-Bleda, M.J.},
+    title={Behaviour-Based Clustering of Neural Networks Applied to Document Enhancement},
+    year={2007},
+    url={https://link.springer.com/chapter/10.1007/978-3-540-73007-1_18},
+    booktitle={Computational and Ambient Intelligence}
+}
+
+@inproceedings{ref_icdar,
+    title={ICDAR 2019 CROHME + TFD: Competition on Recognition of Handwritten Mathematical Expressions and Typeset Formula Detection},
+    author={Mahdavi, Mahshad and Zanibbi, Richard and Mouchere, Harold and Viard-Gaudin, Christian and Garain, Utpal},
+    year={2019},
+    booktitle={International Conference on Document Analysis and Recognition (ICDAR)},
+    url={https://tc11.cvc.uab.es/datasets/ICDAR2019-CROHME-TDF_1}
+}
+
+@misc{ref_UCIMLR,
+    author={Dua, D. and Graff, C.},
+    year={2019},
+    title={UCI Machine Learning Repository},
+}
+
+% DocCreator
+@article{ref_DocCreator,
+AUTHOR = {Journet, Nicholas and Visani, Muriel and Mansencal, Boris and Van-Cuong, Kieu and Billy, Antoine},
+TITLE = {DocCreator: A New Software for Creating Synthetic Ground-Truthed Document Images},
+JOURNAL = {Journal of Imaging},
+VOLUME = {3},
+YEAR = {2017},
+NUMBER = {4},
+ARTICLE-NUMBER = {62},
+URL = {https://www.mdpi.com/2313-433X/3/4/62},
+ISSN = {2313-433X},
+DOI = {10.3390/jimaging3040062}
+}
+
+% albumentations
+@Article{ref_albumentations,
+AUTHOR = {Buslaev, Alexander and Iglovikov, Vladimir I. and Khvedchenya, Eugene and Parinov, Alex and Druzhinin, Mikhail and Kalinin, Alexandr A.},
+TITLE = {Albumentations: Fast and Flexible Image Augmentations},
+JOURNAL = {Information},
+VOLUME = {11},
+YEAR = {2020},
+NUMBER = {2},
+ARTICLE-NUMBER = {125},
+URL = {https://www.mdpi.com/2078-2489/11/2/125},
+ISSN = {2078-2489},
+DOI = {10.3390/info11020125}
+}
+
+% fastai
+@article{ref_fastai,
+    title={Fastai: A Layered API for Deep Learning},
+    author={Howard, Jeremy and Sylvain, Gugger},
+    year={2020},
+    journal={Information},
+    number={2},
+    volume={11},
+    url={https://arxiv.org/pdf/2002.04688.pdf}
+}
+
+% imgaug
+@misc{ref_imgaug,
+  author = {Jung, Alexander B.
+            and Wada, Kentaro
+            and Crall, Jon
+            and Tanaka, Satoshi
+            and Graving, Jake
+            and Reinders, Christoph
+            and Yadav, Sarthak
+            and Banerjee, Joy
+            and Vecsei, Gábor
+            and Kraft, Adam
+            and Rui, Zheng
+            and Borovec, Jirka
+            and Vallentin, Christian
+            and Zhydenko, Semen
+            and Pfeiffer, Kilian
+            and Cook, Ben
+            and Fernández, Ismael
+            and De Rainville, François-Michel
+            and Weng, Chi-Hung
+            and Ayala-Acevedo, Abner
+            and Meudec, Raphael
+            and Laporte, Matias
+            and others},
+  title = {{imgaug}},
+  howpublished = {\url{https://github.com/aleju/imgaug}},
+  year = {2020},
+  note = {Online; accessed 01-Feb-2020}
+}
+
+% augly
+@ARTICLE{Papakipos2022-gq-augly,
+  author = {Papakipos, Zo\:{e} and Bitton, Joanna},
+  title         = "{AugLy}: Data Augmentations for Robustness",
+  year          =  2022,
+  copyright     = "http://creativecommons.org/licenses/by/4.0/",
+  archivePrefix = "arXiv",
+  primaryClass  = "cs.AI",
+  eprint        = "2201.06494",
+  journal       = "arXiv preprint arXiv:2201:06494"
+}
+
+% augmentor
+@article{augmentor,
+    author = {Bloice, Marcus D and Roth, Peter M and Holzinger, Andreas},
+    title = "{Biomedical image augmentation using Augmentor}",
+    journal = {Bioinformatics},
+    volume = {35},
+    number = {21},
+    pages = {4522-4524},
+    year = {2019},
+    month = {04},
+    issn = {1367-4803},
+    doi = {10.1093/bioinformatics/btz259},
+    url = {https://doi.org/10.1093/bioinformatics/btz259},
+    eprint = {https://academic.oup.com/bioinformatics/article-pdf/35/21/4522/30330763/btz259.pdf}
+}
+
+% pytorch
+@incollection{pytorch,
+title = {PyTorch: An Imperative Style, High-Performance Deep Learning Library},
+author = {Paszke, Adam and Gross, Sam and Massa, Francisco and Lerer, Adam and Bradbury, James and Chanan, Gregory and Killeen, Trevor and Lin, Zeming and Gimelshein, Natalia and Antiga, Luca and Desmaison, Alban and Kopf, Andreas and Yang, Edward and DeVito, Zachary and Raison, Martin and Tejani, Alykhan and Chilamkurthy, Sasank and Steiner, Benoit and Fang, Lu and Bai, Junjie and Chintala, Soumith},
+booktitle = {Advances in Neural Information Processing Systems 32},
+pages = {8024--8035},
+year = {2019},
+publisher = {Curran Associates, Inc.},
+url = {http://papers.neurips.cc/paper/9015-pytorch-an-imperative-style-high-performance-deep-learning-library.pdf}
+}
+
+@inproceedings{wei-zou-2019-eda,
+    title = "{EDA}: Easy Data Augmentation Techniques for Boosting Performance on Text Classification Tasks",
+    author = "Wei, Jason  and
+      Zou, Kai",
+    booktitle = "Proceedings of the 2019 Conference on Empirical Methods in Natural Language Processing and the 9th International Joint Conference on Natural Language Processing (EMNLP-IJCNLP)",
+    month = nov,
+    year = "2019",
+    address = "Hong Kong, China",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/D19-1670",
+    doi = "10.18653/v1/D19-1670",
+    pages = "6382--6388"
+}
+
+% survey for data augmentation in NLP
+@inproceedings{feng-etal-2021-survey,
+    title = "A Survey of Data Augmentation Approaches for {NLP}",
+    author = "Feng, Steven Y.  and
+      Gangal, Varun  and
+      Wei, Jason  and
+      Chandar, Sarath  and
+      Vosoughi, Soroush  and
+      Mitamura, Teruko  and
+      Hovy, Eduard",
+    booktitle = "Findings of the Association for Computational Linguistics: ACL-IJCNLP 2021",
+    month = aug,
+    year = "2021",
+    address = "Online",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2021.findings-acl.84",
+    doi = "10.18653/v1/2021.findings-acl.84",
+    pages = "968--988"
+}
+
+% machine translation
+@inproceedings{fadaee-etal-2017-data,
+    title = "Data Augmentation for Low-Resource Neural Machine Translation",
+    author = "Fadaee, Marzieh  and
+      Bisazza, Arianna  and
+      Monz, Christof",
+    booktitle = "Proceedings of the 55th Annual Meeting of the Association for Computational Linguistics (Volume 2: Short Papers)",
+    month = jul,
+    year = "2017",
+    address = "Vancouver, Canada",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/P17-2090",
+    doi = "10.18653/v1/P17-2090",
+    pages = "567--573"
+}
+
+@inproceedings{audio-framework,
+title = "A software framework for musical data augmentation",
+author = "Brian McFee and Humphrey, {Eric J.} and Bello, {Juan P.}",
+year = "2015",
+language = "English (US)",
+series = "Proceedings of the 16th International Society for Music Information Retrieval Conference, ISMIR 2015",
+publisher = "International Society for Music Information Retrieval",
+pages = "248--254",
+editor = "Meinard Muller and Frans Wiering",
+booktitle = "Proceedings of the 16th International Society for Music Information Retrieval Conference, ISMIR 2015"
+}
+
+% speech recognition
+@inproceedings{ko15_interspeech,
+  author={Tom Ko and Vijayaditya Peddinti and Daniel Povey and Sanjeev Khudanpur},
+  title={{Audio augmentation for speech recognition}},
+  year=2015,
+  booktitle={Proc. Interspeech 2015},
+  pages={3586--3589},
+  doi={10.21437/Interspeech.2015-711}
+}
+
+@article{audiogmenter,
+    author={Maguolo, G. and Paci, M. and Nanni, L. and Bonan, L.},
+    title={Audiogmenter: a MATLAB toolbox for audio data augmentation},
+    year={2021},
+    journal={Applied Computing and Informatics}
+}
+
+@ARTICLE{Hosseini2017-kn-google-api,
+  title         = "Google's Cloud Vision {API} is not robust to noise",
+  author        = "Hosseini, Hossein and Xiao, Baicen and Poovendran, Radha",
+  year          =  2017,
+  copyright     = "http://arxiv.org/licenses/nonexclusive-distrib/1.0/",
+  archivePrefix = "arXiv",
+  primaryClass  = "cs.CV",
+  eprint        = "1704.05051",
+  journal = "arXiv preprint arXiv:1704:05051"
+}
+
+@ARTICLE{Vasiljevic2016-al-bluring-impact,
+  title         = "Examining the impact of blur on recognition by convolutional
+                   networks",
+  author        = "Vasiljevic, Igor and Chakrabarti, Ayan and Shakhnarovich,
+                   Gregory",
+  year          =  2016,
+  copyright     = "http://arxiv.org/licenses/nonexclusive-distrib/1.0/",
+  archivePrefix = "arXiv",
+  primaryClass  = "cs.CV",
+  eprint        = "1611.05760",
+  journal       = "arXiv preprint arXiv:1611.05760"
+}
+
+@INPROCEEDINGS{face-recognition-impact,  author={Karahan, Samil and Kilinc Yildirum, Merve and Kirtac, Kadir and Rende, Ferhat Sukru and Butun, Gultekin and Ekenel, Hazim Kemal},  booktitle={2016 International Conference of the Biometrics Special Interest Group (BIOSIG)},   title={How Image Degradations Affect Deep CNN-Based Face Recognition?},   year={2016},  volume={},  number={},  pages={1-5},  doi={10.1109/BIOSIG.2016.7736924}}
+
+@INPROCEEDINGS{image-quality-impact,  author={Dodge, Samuel and Karam, Lina},  booktitle={2016 Eighth International Conference on Quality of Multimedia Experience (QoMEX)},   title={Understanding how image quality affects deep neural networks},   year={2016},  volume={},  number={},  pages={1-6},  doi={10.1109/QoMEX.2016.7498955}}
+
+% imagenet-c
+@inproceedings{imagenet-c,
+    title = {Benchmarking Neural Network Robustness to Common Corruptions and Perturbations},
+    author = {Hendrycks, Dan and Dietterich, Thomas},
+    booktitle = {International Conference on Learning Representations (ICLR)},
+    year = {2019}
+}
+
+@article {pathology-schomig,
+    Title = {Quality control stress test for deep learning-based diagnostic model in digital pathology},
+    Author = {Schömig-Markiefka, Birgid and Pryalukhin, Alexey and Hulla, Wolfgang and Bychkov, Andrey and Fukuoka, Junya and Madabhushi, Anant and Achter, Viktor and Nieroda, Lech and Büttner, Reinhard and Quaas, Alexander and Tolkach, Yuri},
+    DOI = {10.1038/s41379-021-00859-x},
+    Number = {12},
+    Volume = {34},
+    Month = {December},
+    Year = {2021},
+    Journal = {Modern pathology : an official journal of the United States and Canadian Academy of Pathology, Inc},
+    ISSN = {0893-3952},
+    Pages = {2098L = {https://europepmc.org/articles/PMC8592835}
+}
+
+@article{pathology-recommendations,
+    title={Recommendations on test datasets for evaluating AI solutions in pathology},
+    author={Homeyer, Andr\'{e} and Gei{\ss}ler, Christian and Schwen, Lars Ole and Zakrzewski, Falk and Evans, Theodore and Strohmenger, Klaus and Westphal, Max and B\"{u}low, David and Kargl, Michaela and Karjauv, Aray and Munn\'{e}-Bertran, Isidre and Retzlaff, Carl Orge and Romero-L\'{o}pez, Adri\`{a} and So{\l}tysi\'{n}ski, Tomasz and Plass, Markus and Carvalho, Rita and Steinbach, Peter and Lan, Yu-Chia and Bouteldja, Nassim and Haber, David and Rojas-Carulla, Mateo and Sadr, Alireza Vafaei and Kraft, Matthias and Kr\"{u}ger, Daniel and Tick, Rutger and Lang, Tobias and Boor, Peter and M\"{u}ller, Heimo and Hufnagl, Peter and Zerbe, Norman},
+    journal={arXiv preprint arXiv:2204.14226},
+    year={2022},
+    url={https://arxiv.org/pdf/2204.14226.pdf}
+}
+
+@inproceedings{saifullah-2022,
+title={Are Deep Models Robust against Real Distortions? A Case Study on Document Image Classification},
+year={2022},
+author={Saifullah and Siddiqui, Shoaib Ahmed and Agne, Stefan and Dengel, Andreas and Ahmed, Sheraz},
+booktitle={Proceedings of the 26th International Conference on Pattern Recognition (ICPR)},
+url={https://www.computer.org/csdl/proceedings-article/icpr/2022/09956167/1IHoLM9J3gI}
+}

--- a/paper.tex
+++ b/paper.tex
@@ -7,7 +7,18 @@
 }
 \usepackage{listings}
 \usepackage{courier}
+\usepackage{booktabs}
+\usepackage[dvipsnames]{xcolor}
+\usepackage{amssymb}
+\usepackage{pifont}
 \renewcommand{\floatpagefraction}{.8}
+
+% check mark and x for table
+\newcommand{\cmark}{{\color{ForestGreen}\ding{51}}}%
+\newcommand{\xmark}{{\color{Maroon}\ding{55}}}%
+
+\newcommand{\numAugraphyAugmentations}{\emph{n}}
+
 %
 \begin{document}
 
@@ -34,34 +45,80 @@ Augraphy was created as a way to generate features that mimic those of real-worl
 
 Most often, source documents are too old, and often were created before the advent of digital storage media. Some documents are one-offs, produced ad-hoc in the typewriter era, but many more still were printed directly from the text editor used to write them, with no copy saved even after it became possible to do so. Document analysis and understanding tasks require these clean images for analysis. For these reasons, it's much easier to take clean documents and add distorting features to them with a tool like Augraphy than to start with the warped images and find or create ground-truths.
 
-\section{NoisyOffice}
-Many document-focused datasets exist, but most are designed for tasks like layout detection \cite{ref_RDCL2019}, content extraction \cite{ref_tobacco800}, or handwriting recognition \cite{ref_icdar}. the only publically-available dataset we could find that was exclusively focused on digitally-generated modern documents was NoisyOffice \cite{ref_NoisyOffice}.\\
+\begin{table}[]
+    \centering
+    \caption{Comparison of various image-based data augmentation libraries.}
+    \scalebox{0.9}{
+    \begin{tabular}{lccccc}
+    \toprule
+        \textbf{Library} & \textbf{Num.} & \textbf{Document-} & \textbf{Pipeline-} & & \\
+        \textbf{Name} & \textbf{Augmentations} & \textbf{Centric} & \textbf{Based} & \textbf{Python} & \textbf{License}  \\
+    \midrule
+        \emph{Augmentor} \cite{augmentor} & & \xmark &  & \cmark & MIT \\ 
+        \emph{Albumentations} \cite{ref_albumentations} &  & \xmark & \cmark & \cmark & MIT \\
+        \emph{imgaug} \cite{ref_imgaug} & & \xmark & \cmark & \cmark & MIT \\
+        \emph{Augly} \cite{Papakipos2022-gq-augly} & & \xmark & & \cmark & MIT \\
+        \emph{Pytorch} \cite{pytorch} & & \xmark & \cmark & \cmark & BSD-style \\
+        \emph{DocCreator} \cite{ref_DocCreator} & & \cmark & \xmark & \xmark & LGPL-3.0 \\
+        \emph{Augraphy} (ours) & \numAugraphyAugmentations & \cmark & \cmark & \cmark & MIT\\
+    \bottomrule
+    \end{tabular}}
+    \label{tab:augmentation-library-comparison}
+\end{table}
 
-This database \cite{ref_NoisyOfficeDatabase}, hosted on the UCI Machine Learning Repository \cite{ref_UCIMLR}, was created for training image processing filters, including denoisers and superresolution models. NoisyOffice includes three types of image:
+\section{Related Work}
 
-\begin{enumerate}
-\item ground truth images, created by printing some text and re-digitizing the physical document with a digital scanner,
-\item synthetic noisy images, created by digitally fusing the text foreground with a background image of a coffee-stained or boot-printed page, using technique 1 above, and
-\item real noisy images, created by physically stepping with boots onto physical documents, adding real coffee stains, and so on.
-\end{enumerate}
+%This section discusses prior work related to document data augmentation, robustness testing, and document de-noising.
+This section discusses prior work related to data augmentation and robustness testing, especially as it relates to document understanding and processing tasks.
 
-Assembling the NoisyOffice database was a great service to the document analysis community, but for our purposes, the set is too limited:
+\subsection{Data Augmentation}
+A wide variety of data augmentation tools and pipelines exist for machine learning tasks ranging from natural language processing (e.g., \cite{feng-etal-2021-survey,fadaee-etal-2017-data,wei-zou-2019-eda}), audio and speech processing (e.g., \cite{ko15_interspeech,audiogmenter,audio-framework}), and computer vision and image processing.
+In the image realm of image processing and computer vision, data augmentation tools and pipelines include \emph{Augly} \cite{Papakipos2022-gq-augly}, \emph{Augmentor} \cite{augmentor}, \emph{Albumentations} \cite{ref_albumentations}, \emph{DocCreator} \cite{ref_DocCreator}, Pytorch \cite{pytorch}, and \emph{imgaug} \cite{ref_imgaug}.
+Augmentation strategies from these image-centric libraries are typically general purpose, and include image transformations like rotations, warps, and color modifications.
+Table~\ref{tab:augmentation-library-comparison} compares \emph{Augraphy} with other image-based data augmentation libraries and tools.
+As can be seen, these other data augmentation libraries do not specifically provide support for imitating the corruptions commonly seen in document analysis corpora.
 
-\begin{itemize}
-\item it contains only 3 font sizes (footnote, normal, large), 3 font types (typewriter, sans-serif, Roman), italicized and nonitalicized text, and 4 types of noise (folds, wrinkles, coffee stains, and footprints), for a total of 72 unique images.
-\item the text is all English-language
-\item the corpus has already been converted to grayscale, removing any choice about which desaturation algorithm to use
-\item the image sizes provided are quite small (540x420), though double resolution images are also provided for use in training superresolution models.
-\end{itemize}
+A notable exception to this is the \emph{DocCreator} image synthesizing tool \cite{ref_DocCreator}, which is targeted towards creating synthetic images that mimic common corruptions seen in document collections.
+\emph{DocCreator} differs from \emph{Augraphy} in several ways, however.
+The first difference is that \emph{DocCreator}'s augmentations are meant to imitate those seen in historical (e.g., ancient or medieval) documents, while \emph{Augraphy} is meant to replicate noise caused by noisy office room procedures.
+\emph{DocCreator} is also written in the C++ programming language and is a monolithic what-you-see-is-what-you-get (WYSIWYG) tool, and does not have a scripting or API interface to enable use in a broader machine learning pipeline.
+\emph{Augraphy}, in contrast, is written in Python and can be easily integrated into machine learning model development and evaluation pipelines, and can easily be used alongside other Python packages.
 
-Rather than providing a direct answer to these, Augraphy does not generate the initial document image input to a pipeline, instead taking the approach of providing the tools for building a suitable dataset for any document image analysis task while relying on users to supply the ground truth images.
+\subsection{Robustness Testing}
 
-\section{DocCreator}
-In our investigations, the NoisyOffice database was the only preexisting dataset of images of modern documents with realistic distortions we could find; the situation is no better for document-specific feature augmentation tools, with only DocCreator \cite{ref_DocCreator} seeming to occupy that niche.\\
+The introduction of noise-like corruptions and other modifications to image data can be used as a way of estimating and evaluating model robustness.
+Prior work in this space includes the use of image blurring, contrast and brightness changes, color alterations, partial occlusions, geometric transformations, pixel-level noise (e.g., salt-and-pepper noise, impulse noise, etc.), and compression artefacts (e.g., JPEG) to evaluate image classification and object detection models (e.g., \cite{image-quality-impact,imagenet-c,pathology-recommendations,Hosseini2017-kn-google-api,face-recognition-impact,pathology-schomig,Vasiljevic2016-al-bluring-impact}).
+More specific to the document understanding field, recent prior work has used basic noise-like corruptions to evaluate the robustness of document classifiers trained on RVL-CDIP \cite{saifullah-2022}.
+Our paper also uses robustness testing as a way to showcase the effectiveness of \emph{Augraphy}, but rather than general image modifications like those described above, we use document-centric modifications.
 
-DocCreator contains character-set-level distortions, a mechanism for overlaying characters onto an arbitrary paper texture akin to merge technique \#1, and also includes an experimental tool for fusing the document image onto one of several 3D meshes to simulate physical alterations to the document like a crumpled and smoothed page.\\
-
-While an interesting piece of software in its own right, DocCreator is geared towards historical documents like ancient manuscripts and scrolls, and so is unfortunately poorly-suited to generating realistic images of \textit{modern} documents. Worse, the software is a monolithic what-you-see-is-what-you-get editor, with all internals written in \texttt{C++}, making it unsuitable for use either in a semi-automated data augmentation pipeline or by the majority of researchers and industry practitioners who are much more familiar with Python-based tools and expect language-level integration.
+%\section{NoisyOffice}
+%Many document-focused datasets exist, but most are designed for tasks like layout detection \cite{ref_RDCL2019}, content extraction \cite{ref_tobacco800}, or handwriting recognition \cite{ref_icdar}. the only publically-available dataset we could find that was exclusively focused on digitally-generated modern documents was NoisyOffice \cite{ref_NoisyOffice}.\\
+%
+%This database \cite{ref_NoisyOfficeDatabase}, hosted on the UCI Machine Learning Repository \cite{ref_UCIMLR}, was created for training image processing filters, including denoisers and superresolution models. NoisyOffice includes three types of image:
+%
+%\begin{enumerate}
+%\item ground truth images, created by printing some text and re-digitizing the physical document with a digital scanner,
+%\item synthetic noisy images, created by digitally fusing the text foreground with a background image of a coffee-stained or boot-printed page, using technique 1 above, and
+%\item real noisy images, created by physically stepping with boots onto physical documents, adding real coffee stains, and so on.
+%\end{enumerate}
+%
+%Assembling the NoisyOffice database was a great service to the document analysis community, but for our purposes, the set is too limited:
+%
+%\begin{itemize}
+%\item it contains only 3 font sizes (footnote, normal, large), 3 font types (typewriter, sans-serif, Roman), italicized and nonitalicized text, and 4 types of noise (folds, wrinkles, coffee stains, and footprints), for a total of 72 unique images.
+%\item the text is all English-language
+%\item the corpus has already been converted to grayscale, removing any choice about which desaturation algorithm to use
+%\item the image sizes provided are quite small (540x420), though double resolution images are also provided for use in training superresolution models.
+%\end{itemize}
+%
+%Rather than providing a direct answer to these, Augraphy does not generate the initial document image input to a pipeline, instead taking the approach of providing the tools for building a suitable dataset for any document image analysis task while relying on users to supply the ground truth images.
+%
+%\section{DocCreator}
+%In our investigations, the NoisyOffice database was the only preexisting dataset of images of modern documents with realistic distortions we could find; the situation is no better for document-specific feature augmentation tools, with only DocCreator \cite{ref_DocCreator} seeming to occupy that niche.\\
+%
+%DocCreator contains character-set-level distortions, a mechanism for overlaying characters onto an arbitrary paper texture akin to merge technique \#1, and also includes an experimental tool for fusing the document image onto one of several 3D meshes to simulate physical alterations to the document like a crumpled and smoothed page.\\
+%
+%While an interesting piece of software in its own right, DocCreator is geared towards historical documents like ancient manuscripts and scrolls, and so is unfortunately poorly-suited to generating realistic images of \textit{modern} documents. Worse, the software is a monolithic what-you-see-is-what-you-get editor, with all internals written in \texttt{C++}, making it unsuitable for use either in a semi-automated data augmentation pipeline or by the majority of researchers and industry practitioners who are much more familiar with Python-based tools and expect language-level integration.
 
 \section{Document Distortion, Theory \& Technique}
 Many approaches exist for adding features to an image, and many types of feature can be generated. The most common types of features added are Gaussian noise, blurring, geometric transformations like scaling, rotating, translating, and cropping, downsampling, font weighting, and so on.\\


### PR DESCRIPTION
- my opinion is that the section on `NoisyOffice` is more appropriate for the ShabbyPages paper, and not the Augraphy paper, so I commented that section out. I do not think a section dedicated to `Noisy Office` is needed in the Augraphy paper; as it currently stands, the paper has a brief introduction and then jumps right into a discussion about a dataset, which can confuse the reader if they are expecting to read about the Augraphy tool (they would ask, "why am I reading about this dataset if this paper is about a data augmentation tool?").
- I added a dedicated section on `Related Work`, which discusses existing data augmentation tools, and has a discussion on DocCreator (since this tool is the most related to Augraphy). This new `Related Work` section has many references, and discusses two core application areas of Augraphy: data augmentation and robustness testing.
- I added a comparison table (still a work-in-progress, especially the number of augmentations column)

Other note:
- the `paper.bib` file cannot be used until #2 is merged