### PR TITLE
formatting changes for spacing

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -15,6 +15,14 @@
 \usepackage{times}
 \renewcommand{\floatpagefraction}{.8}
 
+% Spacing around floats
+\setlength{\floatsep}{11pt plus 2pt minus 4pt}
+\setlength{\textfloatsep}{11pt plus 2pt minus 4pt}
+\setlength{\dblfloatsep}{\floatsep}
+\setlength{\dbltextfloatsep}{11pt plus 2pt minus 4pt}
+\setlength{\intextsep}{\floatsep}
+\setlength{\abovecaptionskip}{5pt plus 3pt minus 2pt}
+
 % check mark and x for table
 \newcommand{\cmark}{{\color{ForestGreen}\ding{51}}}%
 \newcommand{\xmark}{{\color{Maroon}\ding{55}}}%
@@ -405,19 +413,33 @@ Changes to the document after that point happen within the post layer, where we 
 Use of the Augraphy library to produce a dataset for model training Î
 
 \section{Deep Learning with Augraphy}
-Augraphy aims to facilitate rapid dataset creation, advancing the state of the art for document image analysis tasks. This section describes a brief experiment using Augraphy to augment the NoisyOffice set, producing a corpus that is used to train a denoising convolutional neural network which outperforms an identically-structured model trained on only the provided NoisyOffice data. We continue to return to this database when testing our model training pipelines and new architectures, and felt it an appropriate jumping-off point for Augraphy analysis.
+Augraphy aims to facilitate rapid dataset creation, advancing the state of the art for document image analysis tasks.
+This section describes a brief experiment using Augraphy to augment the NoisyOffice set, producing a corpus that is used to train a denoising convolutional neural network which outperforms an identically-structured model trained on only the provided NoisyOffice data.
+We continue to return to this database when testing our model training pipelines and new architectures, and felt it an appropriate jumping-off point for Augraphy analysis.
 
 \subsection{Model Architecture}
-To evaluate Augraphy, we trained a U-net convolutional neural network, built with the Keras library. This network achieved a high score on the NoisyOffice Kaggle competition \footnote{\url{https://www.kaggle.com/code/michalbrezk/denoise-images-using-autoencoders-tf-keras/notebook}}; we selected this one for its simplicity and the clarity of its exposition, and use it with few changes.\\
+To evaluate Augraphy, we trained a U-net convolutional neural network, built with the Keras library.
+This network achieved a high score on the NoisyOffice Kaggle competition \footnote{\url{https://www.kaggle.com/code/michalbrezk/denoise-images-using-autoencoders-tf-keras/notebook}}; we selected this one for its simplicity and the clarity of its exposition, and use it with few changes.
 
-This low-layer model contains two layers of a convolution, each followed by a rectified linear unit activation function, then a batch normalization layer as the encoding step. After the encoding step, max pooling is applied, followed by dropout, to improve translation invariance of feature encoding and to avoid overfitting respectively. The decoding step closely mirrors the encoding step, and contains two layers of ReLU-activated convolutions followed by a batch normalization layer, but with the convolution dimensions reversed; in this case the model is "unpacking" higher-dimensional features from its low-dimensional latent representation. After the decoding step, we perform 2-dimensional upsampling, compensating for the 2D max pooling applied earlier. Finally, the output of previous layers is convolved with a 3x3 kernel, while retaining the same image dimensions. This final convolution uses the sigmoid function as its activation function. All convolution steps use a 3x3 kernel and pad edges with zeroes, the max pooling and upsampling steps both use 2x2 kernels, and a 50\% unit dropout rate was used.
+This low-layer model contains two layers of a convolution, each followed by a rectified linear unit activation function, then a batch normalization layer as the encoding step.
+After the encoding step, max pooling is applied, followed by dropout, to improve translation invariance of feature encoding and to avoid overfitting respectively.
+The decoding step closely mirrors the encoding step, and contains two layers of ReLU-activated convolutions followed by a batch normalization layer, but with the convolution dimensions reversed; in this case the model is ``unpacking" higher-dimensional features from its low-dimensional latent representation.
+After the decoding step, we perform 2-dimensional upsampling, compensating for the 2D max pooling applied earlier.
+Finally, the output of previous layers is convolved with a 3x3 kernel, while retaining the same image dimensions.
+This final convolution uses the sigmoid function as its activation function.
+All convolution steps use a 3x3 kernel and pad edges with zeroes, the max pooling and upsampling steps both use 2x2 kernels, and a 50\% unit dropout rate was used.
 
 \subsection{Data Generation}
-Despite recent techniques [Training Vision Transformers with Only 2040 Images, Vision Transformer for Small-Size Datasets, Training a Vision Transformer from scratch in less than 24 hours with 1 GPU] for reducing the volume of input data required to train models, data remains king; feeding a model more data during training can help ensure better latent representations of more features, improving robustness of the model and increasing its ability to generalize.\\
+Despite recent techniques [Training Vision Transformers with Only 2040 Images, Vision Transformer for Small-Size Datasets, Training a Vision Transformer from scratch in less than 24 hours with 1 GPU] for reducing the volume of input data required to train models, data remains king; feeding a model more data during training can help ensure better latent representations of more features, improving robustness of the model and increasing its ability to generalize.
 
-The NoisyOffice data provided by Kaggle contains 144 ground truth images, 144 training images, and 72 validation images. For the Augraphy model, we produced a dataset 10x larger, by duplicating each of the ground truth images, then running 10 Augraphy pipelines against each copy. Doing this was trivial; Augraphy's value lies in its ease of use in producing large training sets.\\
+The NoisyOffice data provided by Kaggle contains 144 ground truth images, 144 training images, and 72 validation images.
+For the Augraphy model, we produced a dataset 10x larger, by duplicating each of the ground truth images, then running 10 Augraphy pipelines against each copy.
+Doing this was trivial; Augraphy's value lies in its ease of use in producing large training sets.
 
-The NoisyOffice dataset contains folded sheets, wrinkled sheets, coffee stains, and footprint noise. The features given by the wrinkle and fold distortions can be mimicked by overlaying the foreground text on wrinkled and folded paper textures, as the NoisyOffice team did, and the features created by the stains and footprints can be mimicked by introducing dark regions and thin lines. With Augraphy, we expected that we could use the BadPhotoCopy augmentation to produce the dark regions and a combination of the strikethrough behavior from the Markup augmentation and the smooth curve shading behavior of the PencilScribbles augmentation to add the last feature to the ground-truth data. The PaperFactory augmentation makes the paper texture overlay trivial and repeatable. In the end, we executed the following pipeline:
+The NoisyOffice dataset contains folded sheets, wrinkled sheets, coffee stains, and footprint noise.
+The features given by the wrinkle and fold distortions can be mimicked by overlaying the foreground text on wrinkled and folded paper textures, as the NoisyOffice team did, and the features created by the stains and footprints can be mimicked by introducing dark regions and thin lines.
+With Augraphy, we expected that we could use the BadPhotoCopy augmentation to produce the dark regions and a combination of the strikethrough behavior from the Markup augmentation and the smooth curve shading behavior of the PencilScribbles augmentation to add the last feature to the ground-truth data.
+The PaperFactory augmentation makes the paper texture overlay trivial and repeatable. In the end, we executed the following pipeline:
 
 \begin{lstlisting}
 ink_phase = []
@@ -431,20 +453,24 @@ post_phase = [
 AugraphyPipeline(ink_phase, paper_phase, post_phase)
 \end{lstlisting}
 
-In each of the augmentations created above, the probability of applying to the image passing through the pipeline was set to 50\%, and the strikethrough behavior (the default) for the Markup augmentation was set to strike out words with only black lines.\\
+In each of the augmentations created above, the probability of applying to the image passing through the pipeline was set to 50\%, and the strikethrough behavior (the default) for the Markup augmentation was set to strike out words with only black lines.
 
 The PaperFactory augmentation reads and randomly crops image textures from a local directory; to this we added two \footnote{\url{https://p2.piqsels.com/preview/642/889/110/paper-crease-creased-texture.jpg
 }}, \footnote{\url{https://blog.miklavcic.si/wp-content/uploads/2011/11/white_paper_1.png}} public domain images of wrinkled paper found on Bing.
 
 \subsection{Training Regime}
-We fit the model architecture described in the previous section to both the NoisyOffice corpus and a derivative work generated with Augraphy applied to the NoisyOffice ground truth images.\\
+We fit the model architecture described in the previous section to both the NoisyOffice corpus and a derivative work generated with Augraphy applied to the NoisyOffice ground truth images.
 
-Training proceeded for 600 epochs or until the model began to overfit, with an overfit patience of 30 epochs. The NoisyOffice model finished training after 416 epochs, while the Augraphy model trained for the full 600 epochs.\\
+Training proceeded for 600 epochs or until the model began to overfit, with an overfit patience of 30 epochs.
+The NoisyOffice model finished training after 416 epochs, while the Augraphy model trained for the full 600 epochs.
 
 Both models were trained with mean squared error as the loss function, using the Adam optimizer, and evaluated with the mean average error metric.
 
 \subsection{Results}
-Sample predictions from each model on the validation task are presented in Figure 1. As expected, the NoisyOffice model performs admirably, but does struggle to fully remove the coffee stain feature, leaving some residue. The Augraphy model clearly outperforms the NoisyOffice model at stain removal, but does not generalize well to the folding and wrinkling noise; this was expected, since the Augraphy training data did not include fold or wrinkle features. Further, the Augraphy model overcompensates for the \texttt{BadPhotoCopy} behavior on text, by increasing the line thickness in the predicted text, resulting in a bold font.\\
+Sample predictions from each model on the validation task are presented in Figure 1.
+As expected, the NoisyOffice model performs admirably, but does struggle to fully remove the coffee stain feature, leaving some residue.
+The Augraphy model clearly outperforms the NoisyOffice model at stain removal, but does not generalize well to the folding and wrinkling noise; this was expected, since the Augraphy training data did not include fold or wrinkle features.
+Further, the Augraphy model overcompensates for the \texttt{BadPhotoCopy} behavior on text, by increasing the line thickness in the predicted text, resulting in a bold font.
 
 \begin{figure}\label{fig4}
 \includegraphics[width=\textwidth]{sidebyside.png}
@@ -458,7 +484,10 @@ To compare the models' performance on the validation task, we considered the fol
 \item Peak signal-to-noise ratio (PSNR)
 \end{enumerate}
 
-Over the last 5 epochs of training, the performance of the models on average loss, average mean-average-error (MAE), average validation loss, and average validation MAE were recorded. The models predicted cleaned versions of the validation images (Figure 4), which were then compared to the groundtruth versions according to each metric. The average over all such results obtained during validation was taken. These metrics are displayed in Table 1.
+Over the last 5 epochs of training, the performance of the models on average loss, average mean-average-error (MAE), average validation loss, and average validation MAE were recorded.
+The models predicted cleaned versions of the validation images (Figure 4), which were then compared to the groundtruth versions according to each metric.
+The average over all such results obtained during validation was taken.
+These metrics are displayed in Table 1.
 
 \begin{table}
 \centering
@@ -479,31 +508,46 @@ Training Time & 190ms/step & 218ms/step\\
 \end{tabular}
 \end{table}
 
-The Augraphy model outperforms the PSNR score of the NoisyOffice model on the validation task by half a percent, and has a lower mean average error both in test and validation during training, but underperforms by 0.8\% on structural similarity and 2.5\% on RMSE in validation, with a higher average test and validation loss. These numbers are consistent with the visual prediction results displayed in Figure 1: the Augraphy model predicts fewer pixels in the text (RMSE lower by 2.5\%), but removes more noise and with a higher degree of fidelity than the NoisyOffice model (PSNR higher by 0.2576466946). The training metrics collected indicate that the Augraphy model has lower variance so is more precise than the NoisyOffice model, but exhibits higher loss and thus less accuracy in its predictions.
+The Augraphy model outperforms the PSNR score of the NoisyOffice model on the validation task by half a percent, and has a lower mean average error both in test and validation during training, but underperforms by 0.8\% on structural similarity and 2.5\% on RMSE in validation, with a higher average test and validation loss.
+These numbers are consistent with the visual prediction results displayed in Figure 1: the Augraphy model predicts fewer pixels in the text (RMSE lower by 2.5\%), but removes more noise and with a higher degree of fidelity than the NoisyOffice model (PSNR higher by 0.2576466946).
+The training metrics collected indicate that the Augraphy model has lower variance so is more precise than the NoisyOffice model, but exhibits higher loss and thus less accuracy in its predictions.
 
 \section{Future Work}
 This section describes new directions for research and development.
 
 \subsection{Tuning the Pipeline}
-The pipeline used to generate training data for the Augraphy model was extremely naive, and only contained four augmentations, most with default parameters, demonstrating Augraphy's high degree of both utility and ease-of-use. However, much of the data used in training contained an excessive amount of added noise, making the image unreadable to the human eye, and too noisy to recover text features from. Producing the most accurate model with Augraphy requires careful fine-tuning of the augmentation input parameters to generate training images closer to the validation set.
+The pipeline used to generate training data for the Augraphy model was extremely naive, and only contained four augmentations, most with default parameters, demonstrating Augraphy's high degree of both utility and ease-of-use.
+However, much of the data used in training contained an excessive amount of added noise, making the image unreadable to the human eye, and too noisy to recover text features from.
+Producing the most accurate model with Augraphy requires careful fine-tuning of the augmentation input parameters to generate training images closer to the validation set.
 
 \subsection{Additional Techniques}
-For brevity, this article only includes experimental results for one type of model. We plan to evaluate denoisers built with other architectures, particularly transformers, diffusion and generative adversarial networks, and ensembles of these. During the validation task, the naive Augraphy model correctly removed the page fold and wrinkle noise, but visually degraded regions of the foreground text. By comparison, the NoisyOffice model left more of the text intact, but permitted more of the stain features to remain in the output. Better results may be achieved by a sequential model built from an Augraphy-trained denoiser followed by an inpainting model to repair the text.\\
+For brevity, this article only includes experimental results for one type of model.
+We plan to evaluate denoisers built with other architectures, particularly transformers, diffusion and generative adversarial networks, and ensembles of these.
+During the validation task, the naive Augraphy model correctly removed the page fold and wrinkle noise, but visually degraded regions of the foreground text.
+By comparison, the NoisyOffice model left more of the text intact, but permitted more of the stain features to remain in the output.
+Better results may be achieved by a sequential model built from an Augraphy-trained denoiser followed by an inpainting model to repair the text.
 
 \subsection{An Augraphy Dataset}
-Privacy and security concerns typically preclude the assembly of large sets of modern document images: most documents are not intended for general viewing. The authors have searched frequently, for over a year, and have been unable to find decently-sized (>10 images) sets of modern document images, besides the NoisyOffice set. We intend to release an Augraphy-generated dataset in the coming months.
+Privacy and security concerns typically preclude the assembly of large sets of modern document images: most documents are not intended for general viewing.
+The authors have searched frequently, for over a year, and have been unable to find decently-sized (>10 images) sets of modern document images, besides the NoisyOffice set.
+We intend to release an Augraphy-generated dataset in the coming months.
 
 \subsection{Augraphy Enhancements}
-Several upgrades to the Augraphy library itself are also planned.
+Several upgrades to the Augraphy library itself are also planned:
 
-\subsubsection{Scaling}
-While much work has gone into tuning Augraphy's defaults, and we feel that the effects produced are quite realistic, none of the augmentations were designed to be scale-invariant, and so we plan to introduce pre-trained networks into the library to generate effects in the future.
+%\subsubsection{Scaling}
+\smallskip\noindent\textbf{Scaling.} ~While much work has gone into tuning Augraphy's defaults, and we feel that the effects produced are quite realistic, none of the augmentations were designed to be scale-invariant, and so we plan to introduce pre-trained networks into the library to generate effects in the future.
 
-\subsubsection{Performance}
-The authors typically run substantial Augraphy jobs on enthusiast or datacenter hardware. Performance enhancements to the library are already underway, which will decrease pipeline execution time dramatically, enabling faster creation of larger datasets on more common hardware.
+%\subsubsection{Performance}
+\smallskip\noindent\textbf{Performance.} ~The authors typically run substantial Augraphy jobs on enthusiast or datacenter hardware.
+Performance enhancements to the library are already underway, which will decrease pipeline execution time dramatically, enabling faster creation of larger datasets on more common hardware.
 
 \section{Conclusion}
-We presented Augraphy, an augmentation framework for generating realistic datasets of modern document images. Two other players in the same space were examined and found lacking for our purposes, motivating the creation of this library. We described creating an Augraphy-noised version of the NoisyOffice dataset, then compared some preliminary results obtained by training a convolutional U-Net on these datasets. Finally, we discussed some future directions for research, and the continued evolution of this tool. Augraphy is licensed under the MIT open source license, and readers are invited to participate in its development on GitHub.
+We presented Augraphy, an augmentation framework for generating realistic datasets of modern document images.
+Two other players in the same space were examined and found lacking for our purposes, motivating the creation of this library.
+We described creating an Augraphy-noised version of the NoisyOffice dataset, then compared some preliminary results obtained by training a convolutional U-Net on these datasets.
+Finally, we discussed some future directions for research, and the continued evolution of this tool.
+Augraphy is licensed under the MIT open source license, and readers are invited to participate in its development on GitHub.
 
 
 %


### PR DESCRIPTION
This PR:
- modifies the spacing around table/figure floats to trim excessive whitespace after/before these floats
- removes some `\\` end-of-line characters after paragraphs (the style file will handle this for us)
- breaks up some paragraphs of text so that there is one sentence per line of TeX

The result of the first two items above is a "tighter" paper, allowing us more room to add text/tables/figures